### PR TITLE
fix: додано властивість Items до GroupDescriptions для коректної роботи ContentProperty

### DIFF
--- a/ViewEngines/A2v10.ViewEngine.Xaml/Base/GroupDescription.cs
+++ b/ViewEngines/A2v10.ViewEngine.Xaml/Base/GroupDescription.cs
@@ -30,16 +30,22 @@ public class GroupDescription : XamlElement, IJavaScriptSource
 	}
 }
 
+public class GroupDescriptionItems : List<GroupDescription>
+{
+}
+
 [ContentProperty("Items")]
 [TypeConverter(typeof(GroupDescriptionsConverter))]
-public class GroupDescriptions : List<GroupDescription>, IJavaScriptSource
+public class GroupDescriptions : IJavaScriptSource
 {
+	public GroupDescriptionItems Items { get; set; } = [];
+
 	public String? GetJsValue(RenderContext context)
 	{
-		if (Count == 0)
+		if (Items.Count == 0)
 			return null;
 		StringBuilder sb = new("[");
-		foreach (var d in this)
+		foreach (var d in Items)
 		{
 			sb.Append(d.GetJsValue(context)).Append(',');
 		}
@@ -70,7 +76,7 @@ internal class GroupDescriptionsConverter : TypeConverter
 				GroupBy = strVal,
 				Count = true
 			};
-			coll.Add(gd);
+			coll.Items.Add(gd);
 			return coll;
 		}
 		throw new XamlException($"Invalid GroupDescriptions value '{value}'");

--- a/ViewEngines/A2v10.ViewEngine.Xaml/Controls/DataGrid.cs
+++ b/ViewEngines/A2v10.ViewEngine.Xaml/Controls/DataGrid.cs
@@ -63,7 +63,7 @@ public class DataGrid : Control
 	{
 		get
 		{
-			_groupBy ??= [];
+			_groupBy ??= new GroupDescriptions();
 			return _groupBy;
 		}
 		set { _groupBy = value; }


### PR DESCRIPTION
## Опис

Клас `GroupDescriptions` має атрибут `[ContentProperty("Items")]`, але успадковується від 
`List<GroupDescription>`, який не має властивості `Items`. Це призводить до помилки 
XAML-парсера (`A2v10.System.Xaml`, `NodeBuilder.BuildTypeDescriptor`):

> Property Items not found in type A2v10.Xaml.GroupDescriptions

при обробці XAML з дочірніми елементами `<GroupDescription>` всередині `<GroupDescriptions>` 
(наприклад, групування DataGrid через ComboBox).

### Зміни

- Додано клас-обгортку `GroupDescriptionItems : List<GroupDescription>`
- Замінено успадкування від `List<GroupDescription>` на явну властивість `Items`
- Оновлено `GetJsValue()` та `GroupDescriptionsConverter` для роботи через `Items`
- Виправлено геттер `DataGrid.GroupBy`: `new GroupDescriptions()` замість `[]`

Аналогічний патерн вже використовується для `FilterDescription` / `FilterItems` в цій кодовій базі.


Приклад рішення яке я в себе використовую в локальній версії платформи