### PR TITLE
fix(url): createUrlForNavigate must not mutate its argument (strips Id from bound objects)

### DIFF
--- a/Platform/A2v10.Web.Assets/wwwroot/scripts/main.js
+++ b/Platform/A2v10.Web.Assets/wwwroot/scripts/main.js
@@ -1324,8 +1324,11 @@ app.modules['std:url'] = function () {
 			urlId = urlId.$id;
 		else if (utils.isObjectExact(urlId)) {
 			urlId = data.Id;
-			delete data['Id'];
-			qs = makeQueryString(data);
+			// do not mutate the caller object (it may be a bound reactive model/filter):
+			// clone before stripping Id, otherwise the original loses its Id key
+			let rest = Object.assign({}, data);
+			delete rest['Id'];
+			qs = makeQueryString(rest);
 			if (!utils.isDefined(urlId))
 				urlId = 'new';
 		}

--- a/Platform/A2v10.Web.Assets/wwwroot/scripts/tabmain.js
+++ b/Platform/A2v10.Web.Assets/wwwroot/scripts/tabmain.js
@@ -1324,8 +1324,11 @@ app.modules['std:url'] = function () {
 			urlId = urlId.$id;
 		else if (utils.isObjectExact(urlId)) {
 			urlId = data.Id;
-			delete data['Id'];
-			qs = makeQueryString(data);
+			// do not mutate the caller object (it may be a bound reactive model/filter):
+			// clone before stripping Id, otherwise the original loses its Id key
+			let rest = Object.assign({}, data);
+			delete rest['Id'];
+			qs = makeQueryString(rest);
 			if (!utils.isDefined(urlId))
 				urlId = 'new';
 		}


### PR DESCRIPTION
### Problem

`std:url` `createUrlForNavigate(url, data)` mutates the object passed to it:

```js
else if (utils.isObjectExact(urlId)) {
    urlId = data.Id;
    delete data['Id'];              // <-- mutates the caller's object
    qs = makeQueryString(data);
    ...
}
```

It strips `Id` in order to build the query string from the remaining fields. But `data` is often a **live, bound reactive model**, not a throwaway. Deleting `Id` removes the key from that reactive object.

### How it manifests

An `Open` command is the only command that emits an **eager** `:href` binding (`GetHrefForCommand` → `$href(url, arg)`), which is evaluated at render time (and re-evaluated reactively). So:

```
<Hyperlink Command="{BindCmd Open, Argument={Bind Parent.Filter.Project}, Url='/catalog/x/edit'}" .../>
```

renders `:href="$href('/catalog/x/edit', Parent.Filter.Project)"`. On render this calls `createUrlForNavigate`, which does `delete Parent.Filter.Project['Id']`. The bound filter object goes from `{ Id, Name }` to `{ Name }`.

That alone looks harmless, but a `Selector` Browse pick writes back via `simpleMerge(target, result)`, which only copies keys **already present** on the target. With `Id` gone, `Id` is never restored, so the filter silently stops filtering. (Fetch / manual entry keep working because they replace the whole object rather than merging into it.)

More generally: **any `Open` hyperlink bound to a data object strips that object's `Id` at render.** It usually goes unnoticed because the object isn't read again, but it is a latent correctness bug.

### Fix

Clone before removing `Id` so the caller's object is left intact:

```js
else if (utils.isObjectExact(urlId)) {
    urlId = data.Id;
    let rest = Object.assign({}, data);
    delete rest['Id'];
    qs = makeQueryString(rest);
    ...
}
```

No behavior change to the produced URL/querystring — only the input object is no longer mutated.

### Notes

- Fixed in the canonical package assets: `Platform/A2v10.Web.Assets/wwwroot/scripts/main.js` and `tabmain.js` (identical code in both shells).
- The same code also lives in the minified bundles (`*.min.js`) and the sample `Web/A2v10.Core.Web.Site` copy — those are generated/copied, so I left them for your build to regenerate. Happy to include them if you prefer.
