### PR TITLE
fix(collection-view): clamp page offset when the filtered set shrinks

### DIFF
--- a/Platform/A2v10.Web.Assets/wwwroot/scripts/main.js
+++ b/Platform/A2v10.Web.Assets/wwwroot/scripts/main.js
@@ -9313,8 +9313,13 @@ TODO:
 				// HACK!
 				this.filteredCount = arr.length;
 				// pager
-				if (this.pageSize > 0)
-					arr = arr.slice(this.offset, this.offset + this.pageSize);
+				if (this.pageSize > 0) {
+					// when the filtered set shrank below the current offset, the page would be
+					// empty with a dead pager button — clamp back to the first page
+					if (this.offset >= arr.length && arr.length > 0)
+						this.localQuery.offset = 0;
+					arr = arr.slice(this.localQuery.offset, this.localQuery.offset + this.pageSize);
+				}
 				arr.$origin = this.ItemsSource;
 				if (arr.indexOf(arr.$origin.$selected) === -1) {
 					// not found in target array

--- a/Platform/A2v10.Web.Assets/wwwroot/scripts/tabmain.js
+++ b/Platform/A2v10.Web.Assets/wwwroot/scripts/tabmain.js
@@ -9339,8 +9339,13 @@ TODO:
 				// HACK!
 				this.filteredCount = arr.length;
 				// pager
-				if (this.pageSize > 0)
-					arr = arr.slice(this.offset, this.offset + this.pageSize);
+				if (this.pageSize > 0) {
+					// when the filtered set shrank below the current offset, the page would be
+					// empty with a dead pager button — clamp back to the first page
+					if (this.offset >= arr.length && arr.length > 0)
+						this.localQuery.offset = 0;
+					arr = arr.slice(this.localQuery.offset, this.localQuery.offset + this.pageSize);
+				}
 				arr.$origin = this.ItemsSource;
 				if (arr.indexOf(arr.$origin.$selected) === -1) {
 					// not found in target array


### PR DESCRIPTION
### Problem

A client-side `CollectionView` (with `FilterDelegate` + paging) stores its page offset in `localQuery.offset`. When the filter reduces the result set below the current offset — e.g. switching to a group / filter value with fewer rows — `pagedSource` sliced past the end of the filtered array:

```js
if (this.pageSize > 0)
    arr = arr.slice(this.offset, this.offset + this.pageSize);
```

The result was an **empty page with a dead (disabled) pager button**: the pager thought it was on page N, the filtered array only had enough for page 1, so `slice` returned `[]` and the user was stuck until manually paging back.

### Fix

Clamp the offset back to the first page when it lands beyond the filtered length, and slice from `localQuery.offset` directly so the correction takes effect on the **same** render (`this.offset` is a cached computed and would otherwise lag one reactive cycle):

```js
if (this.pageSize > 0) {
    if (this.offset >= arr.length && arr.length > 0)
        this.localQuery.offset = 0;
    arr = arr.slice(this.localQuery.offset, this.localQuery.offset + this.pageSize);
}
```

### Notes

- Applied to both shells: `Platform/A2v10.Web.Assets/wwwroot/scripts/main.js` and `tabmain.js`.
- The minified bundles (`*.min.js`) and the sample `Web/A2v10.Core.Web.Site` copy carry the same code — left for your build to regenerate.
